### PR TITLE
Add flash card functionality

### DIFF
--- a/src/client/src/App.jsx
+++ b/src/client/src/App.jsx
@@ -1,28 +1,117 @@
-import "./App.css";
 import { Routes, Route, BrowserRouter as Router, } from "react-router-dom";
 import React, {useEffect, useState} from "react";
+import { FlashCardPage } from "./FlashCard/Page";
 
-const Placeholder = () => {
-    const [users, setUsers] = useState([]);
 
-    useEffect(() => {
-        fetch('/api/users').then( async (user) => {
-            const usersReturned = await user.json();
-            setUsers(Object.values(usersReturned)[0])
+const DUMMY_FLASH_CARDS = [
+  {
+    id: 1,
+    term: 'andrew',
+    definition: 'spencer',
+  },
+];
+
+// Make sure this is unique!
+let nextId = 2;
+
+/**
+ * 
+ * @param {*} props onSubmit function
+ */
+function FlashCardForm(props) {
+  const { onSubmit } = props;
+  // Could use this to edit existing data, so initial values would be here:
+  const [term, setTerm] = useState('');
+  const [definition, setDefinition] = useState('');
+  const [dataIsPosting, setDataIsPosting] = useState(false);
+
+  return (
+    <form onSubmit={(event) => {
+      event.preventDefault();
+      // POST to API, deal with errors, etc. with { term, definition }
+      // Return an object with those values and unique id.
+      // Trigger reload.
+      const id = nextId;
+      nextId += 1;
+      setDataIsPosting(true);
+      // If we add `await onSubmit`, then the button should be disabled.
+      onSubmit({ id, term, definition });
+      setDataIsPosting(false);
+      setTerm('');
+      setDefinition('');
+    }}>
+      <label htmlFor="flashCardTerm">Term:</label>
+      <input id="flashCardTerm" name="term" value={term} onChange={(event) => {
+        setTerm(event.target.value);
+      }} />
+      <label htmlFor="flashCardDefinition">Definition:</label>
+      <input id="flashCardDefinition" name="definition" value={definition} onChange={(event) => {
+        setDefinition(event.target.value);
+      }} />
+      <button type="submit" disabled={dataIsPosting}>Add New Flash Card</button>
+    </form>
+  )
+}
+
+const FlashCards = () => {
+  const [flashCards, setFlashCards] = useState([]);
+  const [dataIsLoading, setDataIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [flashCardFormIsVisible, setFlashCardFormIsVisible] = useState(false);
+
+  useEffect(() => {
+    let requestIsCurrent = true;
+
+    async function getFlashCards() {
+      try {
+        setDataIsLoading(true);
+        const apiFlashCards = await new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(DUMMY_FLASH_CARDS);
+          }, 500);
+        });
+        if (requestIsCurrent) {
+          setFlashCards(apiFlashCards);
+          setDataIsLoading(false);
+        }
+      } catch (error) {
+        if (requestIsCurrent) {
+          setErrorMessage(string(error));
+        }
+      }
+    }
+    getFlashCards();
+    return () => {
+      requestIsCurrent = false;
+    }
+  }, []);
+  if (dataIsLoading) {
+    return <p>Data Is Loading...</p>
+  }
+  if (errorMessage) {
+    return <p>Data failed to load: {errorMessage}</p>
+  }
+  return (
+  <>
+    <FlashCardPage flashCards={flashCards} />
+    <button onClick={() => {setFlashCardFormIsVisible(true)}}>Add Flash Card</button>
+    {flashCardFormIsVisible && "test"}
+    {flashCardFormIsVisible && <FlashCardForm onSubmit={
+      (newCard) => {
+        setFlashCards((flashCards) => {
+          return [...flashCards, newCard];
         })
-    }, []);
-
-    return <div>{users.join(',')}</div>
+      }
+    }/>}
+  </>);
 };
 
 function App() {
-
-
   return (
     <div className="App">
       <Router>
           <Routes>
-              <Route path="/flashcards" element={<Placeholder/>} />
+              <Route path="/flashcards" element={<FlashCards/>} />
           </Routes>
       </Router>
     </div>

--- a/src/client/src/FlashCard/Card.jsx
+++ b/src/client/src/FlashCard/Card.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+/**
+ * interface IFlashCard {
+ *  id: number;
+ *  term: string;
+ *  definition: string;
+ * }}
+ * interface IFlashCardProps { 
+ *  card: IFlashCard;
+ * }
+ */
+
+export function FlashCard(props) {
+  const { card: { term, definition } } = props;
+
+  return (
+    <div>
+      <p>Term: {term}</p>
+      <p>Definition: {definition}</p>
+    </div>
+  );
+}

--- a/src/client/src/FlashCard/Page.jsx
+++ b/src/client/src/FlashCard/Page.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { FlashCard } from './Card';
+
+/**
+ * 
+ * @param {*} props flashCards: IFlashCardProps[]
+ */
+export function FlashCardPage(props) {
+  const { flashCards } = props;
+  return (
+    <div>
+      {flashCards.map((card) => {
+        return <FlashCard key={card.id} card={card} />
+      })}
+    </div>
+  )
+}


### PR DESCRIPTION
As part of the interview process, add initial flash card functionality.

[Add FlashCard component.](https://github.com/cashew-systems/cashew-react-focused-interview-starter/commit/c2756a1e474f7c3e38a64c7fd49ed9036b973139) 

Add a simple card example
 
[Add FlashCardPanel component](https://github.com/cashew-systems/cashew-react-focused-interview-starter/commit/ae1b02e4fb846377c1e826e14dc2ba377975b940) 

A component that shows zero or more cards.
 
[Add FlashCard API emulation](https://github.com/cashew-systems/cashew-react-focused-interview-starter/commit/a84f514fe530515be39bc5587c7cac8bc6e455f1) 

As part of an interview, add code to support flah cards.

* Emulate API to handles loading state, error, and resolved data.
* Handle race condition potential.
* Add visual representation for flash cards, loading, and error
* Add `form` and button to add flash card

![image](https://user-images.githubusercontent.com/5629800/230173829-f984b7de-8839-42b2-8aee-0e0bd1cfec2d.png)
